### PR TITLE
Moved away from "postinstall" script to "copy-files-from-to" script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "login",
-  "version": "0.0.3",
+  "name": "login-express-session",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple example of a server rendered app that enables login, logout and secure routes using node, express, express-session, pug and bootstrap.",
   "scripts": {
     "start": "node ./bin/www",
-    "postinstall": "copy-files-from-to"
+    "copy-files-from-to": "copy-files-from-to"
   },
   "copyFiles": [
     {


### PR DESCRIPTION
Also updated package-lock.json

I realized that my changes for the PR https://github.com/rkristelijn/login/pull/2 meant that the `postinstall` scripts would also run when I attempt to install `login-express-session` package within another project. That leads to errors.

I renamed the scripts from `postinstall` to `copy-files-from-to`.

This means that updating the 3rdparty files would need running `npm run copy-files-from-to`